### PR TITLE
Replace wikimedia with MediaWiki

### DIFF
--- a/r/re/rationale.muse
+++ b/r/re/rationale.muse
@@ -13,7 +13,7 @@ needed.
 
 The problem AmuseWiki wants to address is, anyway, very practical. I
 needed and wanted a decent range of output format. Not just a PDF
-output (wikimedia does that as well, for example), but a nice, good,
+output (MediaWiki does that as well, for example), but a nice, good,
 readable PDF. Now, given that the procedure needs to be completely
 automated, the perfection is hardly reached, but we can do better than
 simply render an HTML page and stuff the output in a PDF container.


### PR DESCRIPTION
Wikimedia is an organization, MediaWiki is a wiki engine.