### PR TITLE
Document the differences in allowed characters before lightweight markup 

### DIFF
--- a/m/ml/manual.muse
+++ b/m/ml/manual.muse
@@ -1515,6 +1515,16 @@ Emphasis and strong can also be written with tags, like =<em>emphasis</em>=,
 Added tag =<sup>= and =<sub>= for superscript and
 subscript.
 
+**** Allowed characters before lightweight markup
+
+Unlike Emacs Muse (as of version 3.20.2), any non-alphanumeric characters
+are allowed before the opening =*= and <code>=</code>. For example, the
+following markup is interpreted as bold code by Amusewiki
+{{{
+**=Bold code=**
+}}}
+while Emacs Muse interprets it as bold "<verbatim>=Bold code=</verbatim>".
+
 *** Block markup
 
 The only tables supported are the native one (with =|||= as separator).

--- a/m/ml/manual.muse
+++ b/m/ml/manual.muse
@@ -1494,7 +1494,7 @@ Emacs Muse compatibility in this regard, material in =<code>= tags and
 equivalent markup between equal signs is also verbatim, but with a
 monospace font.
 
-** Differences between =Text::Amuse= and =Emacs Muse=
+** Differences between =Text::Amuse= and Emacs Muse
 
 Unfortunately, the Emacs Muse project is dead. However,
 [[https://pandoc.org][pandoc]] supports the muse syntax.

--- a/m/ml/manual.muse
+++ b/m/ml/manual.muse
@@ -1501,10 +1501,16 @@ Unfortunately, the Emacs Muse project is dead. However,
 
 *** Inline markup
 
+**** Underlining
+
 Underlining has been dropped.
+
+**** Tags for emphasis
 
 Emphasis and strong can also be written with tags, like =<em>emphasis</em>=,
 =<strong>strong</strong>= and =<code>code</code>=.
+
+**** Superscript and subscript tags
 
 Added tag =<sup>= and =<sub>= for superscript and
 subscript.


### PR DESCRIPTION
I assume it is decided in https://github.com/melmothx/text-amuse/issues/44 that it is not a bug.